### PR TITLE
Close the detector safely

### DIFF
--- a/YOLOv10-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov10objectdetector/Detector.kt
+++ b/YOLOv10-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov10objectdetector/Detector.kt
@@ -111,6 +111,7 @@ class Detector(
         var inferenceTime: Long
         var bestBoxes: List<BoundingBox>
         synchronized(executingLock) {
+            if (interpreter == null) return
             if (tensorWidth == 0
                 || tensorHeight == 0
                 || numChannel == 0

--- a/YOLOv10-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov10objectdetector/Detector.kt
+++ b/YOLOv10-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov10objectdetector/Detector.kt
@@ -23,13 +23,14 @@ class Detector(
     private val detectorListener: DetectorListener,
     private val message: (String) -> Unit
 ) {
-    private var interpreter: Interpreter
+    private var interpreter: Interpreter?
     private var labels = mutableListOf<String>()
 
     private var tensorWidth = 0
     private var tensorHeight = 0
     private var numChannel = 0
     private var numElements = 0
+    private var executingLock = Any()
 
     private val imageProcessor = ImageProcessor.Builder()
         .add(NormalizeOp(INPUT_MEAN, INPUT_STANDARD_DEVIATION))
@@ -56,8 +57,8 @@ class Detector(
 
         labels.forEach(::println)
 
-        val inputShape = interpreter.getInputTensor(0)?.shape()
-        val outputShape = interpreter.getOutputTensor(0)?.shape()
+        val inputShape = interpreter?.getInputTensor(0)?.shape()
+        val outputShape = interpreter?.getOutputTensor(0)?.shape()
 
         if (inputShape != null) {
             tensorWidth = inputShape[1]
@@ -77,7 +78,7 @@ class Detector(
     }
 
     fun restart(isGpu: Boolean) {
-        interpreter.close()
+        interpreter?.close()
 
         val options = if (isGpu) {
             val compatList = CompatibilityList()
@@ -100,35 +101,40 @@ class Detector(
     }
 
     fun close() {
-        interpreter.close()
+        synchronized(executingLock) {
+            interpreter?.close()
+            interpreter = null
+        }
     }
 
     fun detect(frame: Bitmap) {
-        if (tensorWidth == 0
-            || tensorHeight == 0
-            || numChannel == 0
-            || numElements == 0) return
+        var inferenceTime: Long
+        var bestBoxes: List<BoundingBox>
+        synchronized(executingLock) {
+            if (tensorWidth == 0
+                || tensorHeight == 0
+                || numChannel == 0
+                || numElements == 0) return
 
-        var inferenceTime = SystemClock.uptimeMillis()
+            inferenceTime = SystemClock.uptimeMillis()
 
-        val resizedBitmap = Bitmap.createScaledBitmap(frame, tensorWidth, tensorHeight, false)
+            val resizedBitmap = Bitmap.createScaledBitmap(frame, tensorWidth, tensorHeight, false)
 
-        val tensorImage = TensorImage(INPUT_IMAGE_TYPE)
-        tensorImage.load(resizedBitmap)
-        val processedImage = imageProcessor.process(tensorImage)
-        val imageBuffer = processedImage.buffer
+            val tensorImage = TensorImage(INPUT_IMAGE_TYPE)
+            tensorImage.load(resizedBitmap)
+            val processedImage = imageProcessor.process(tensorImage)
+            val imageBuffer = processedImage.buffer
 
-        val output = TensorBuffer.createFixedSize(intArrayOf(1, numChannel, numElements), OUTPUT_IMAGE_TYPE)
-        interpreter.run(imageBuffer, output.buffer)
+            val output = TensorBuffer.createFixedSize(intArrayOf(1, numChannel, numElements), OUTPUT_IMAGE_TYPE)
+            interpreter?.run(imageBuffer, output.buffer)
 
-        val bestBoxes = bestBox(output.floatArray)
-        inferenceTime = SystemClock.uptimeMillis() - inferenceTime
-
+            bestBoxes = bestBox(output.floatArray)
+            inferenceTime = SystemClock.uptimeMillis() - inferenceTime
+        }
         if (bestBoxes.isEmpty()) {
             detectorListener.onEmptyDetect()
             return
         }
-
         detectorListener.onDetect(bestBoxes, inferenceTime)
     }
 

--- a/YOLOv8-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov8tflite/Detector.kt
+++ b/YOLOv8-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov8tflite/Detector.kt
@@ -117,6 +117,7 @@ class Detector(
         var bestBoxes: List<BoundingBox>?
         var inferenceTime: Long
         synchronized(executingLock) {
+            if (interpreter == null) return
             if (tensorWidth == 0
                 || tensorHeight == 0
                 || numChannel == 0

--- a/YOLOv8-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov8tflite/Detector.kt
+++ b/YOLOv8-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov8tflite/Detector.kt
@@ -24,13 +24,14 @@ class Detector(
     private val message: (String) -> Unit
 ) {
 
-    private var interpreter: Interpreter
+    private var interpreter: Interpreter?
     private var labels = mutableListOf<String>()
 
     private var tensorWidth = 0
     private var tensorHeight = 0
     private var numChannel = 0
     private var numElements = 0
+    private var executingLock = Any()
 
     private val imageProcessor = ImageProcessor.Builder()
         .add(NormalizeOp(INPUT_MEAN, INPUT_STANDARD_DEVIATION))
@@ -52,8 +53,8 @@ class Detector(
         val model = FileUtil.loadMappedFile(context, modelPath)
         interpreter = Interpreter(model, options)
 
-        val inputShape = interpreter.getInputTensor(0)?.shape()
-        val outputShape = interpreter.getOutputTensor(0)?.shape()
+        val inputShape = interpreter?.getInputTensor(0)?.shape()
+        val outputShape = interpreter?.getOutputTensor(0)?.shape()
 
         labels.addAll(extractNamesFromMetadata(model))
         if (labels.isEmpty()) {
@@ -83,7 +84,7 @@ class Detector(
     }
 
     fun restart(isGpu: Boolean) {
-        interpreter.close()
+        interpreter?.close()
 
         val options = if (isGpu) {
             val compatList = CompatibilityList()
@@ -106,43 +107,49 @@ class Detector(
     }
 
     fun close() {
-        interpreter.close()
+        synchronized(executingLock) {
+            interpreter?.close()
+            interpreter = null
+        }
     }
 
     fun detect(frame: Bitmap) {
-        if (tensorWidth == 0
-            || tensorHeight == 0
-            || numChannel == 0
-            || numElements == 0) {
-            return
+        var bestBoxes: List<BoundingBox>?
+        var inferenceTime: Long
+        synchronized(executingLock) {
+            if (tensorWidth == 0
+                || tensorHeight == 0
+                || numChannel == 0
+                || numElements == 0) {
+                return
+            }
+
+            inferenceTime = SystemClock.uptimeMillis()
+
+
+
+            val resizedBitmap = Bitmap.createScaledBitmap(frame, tensorWidth, tensorHeight, false)
+
+            val tensorImage = TensorImage(INPUT_IMAGE_TYPE)
+            tensorImage.load(resizedBitmap)
+            val processedImage = imageProcessor.process(tensorImage)
+            val imageBuffer = processedImage.buffer
+
+            println("numChannel: $numChannel")
+            println("numElements: $numElements")
+
+            val output = TensorBuffer.createFixedSize(intArrayOf(1, numChannel, numElements), OUTPUT_IMAGE_TYPE)
+            interpreter?.run(imageBuffer, output.buffer)
+
+            bestBoxes = bestBox(output.floatArray)
+            inferenceTime = SystemClock.uptimeMillis() - inferenceTime
+
         }
-
-        var inferenceTime = SystemClock.uptimeMillis()
-
-
-
-        val resizedBitmap = Bitmap.createScaledBitmap(frame, tensorWidth, tensorHeight, false)
-
-        val tensorImage = TensorImage(INPUT_IMAGE_TYPE)
-        tensorImage.load(resizedBitmap)
-        val processedImage = imageProcessor.process(tensorImage)
-        val imageBuffer = processedImage.buffer
-
-        println("numChannel: $numChannel")
-        println("numElements: $numElements")
-
-        val output = TensorBuffer.createFixedSize(intArrayOf(1, numChannel, numElements), OUTPUT_IMAGE_TYPE)
-        interpreter.run(imageBuffer, output.buffer)
-
-        val bestBoxes = bestBox(output.floatArray)
-        inferenceTime = SystemClock.uptimeMillis() - inferenceTime
-
         if (bestBoxes == null) {
             detectorListener.onEmptyDetect()
             return
         }
-
-        detectorListener.onDetect(bestBoxes, inferenceTime)
+        detectorListener.onDetect(bestBoxes!!, inferenceTime)
     }
 
     private fun bestBox(array: FloatArray) : List<BoundingBox>? {

--- a/YOLOv9-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov9tflite/Detector.kt
+++ b/YOLOv9-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov9tflite/Detector.kt
@@ -28,13 +28,14 @@ class Detector(
     private val message: (String) -> Unit
 ) {
 
-    private var interpreter: Interpreter
+    private var interpreter: Interpreter?
     private var labels = mutableListOf<String>()
 
     private var tensorWidth = 0
     private var tensorHeight = 0
     private var numChannel = 0
     private var numElements = 0
+    private var executingLock = Any()
 
     private val imageProcessor = ImageProcessor.Builder()
         .add(NormalizeOp(INPUT_MEAN, INPUT_STANDARD_DEVIATION))
@@ -66,8 +67,8 @@ class Detector(
             }
         }
 
-        val inputShape = interpreter.getInputTensor(0)?.shape()
-        val outputShape = interpreter.getOutputTensor(0)?.shape()
+        val inputShape = interpreter?.getInputTensor(0)?.shape()
+        val outputShape = interpreter?.getOutputTensor(0)?.shape()
 
         if (inputShape != null) {
             tensorWidth = inputShape[1]
@@ -87,7 +88,7 @@ class Detector(
     }
 
     fun restart(isGpu: Boolean) {
-        interpreter.close()
+        interpreter?.close()
 
         val options = if (isGpu) {
             val compatList = CompatibilityList()
@@ -110,36 +111,41 @@ class Detector(
     }
 
     fun close() {
-        interpreter.close()
+        synchronized(executingLock) {
+            interpreter?.close()
+            interpreter = null
+        }
     }
 
     fun detect(frame: Bitmap) {
-        if (tensorWidth == 0) return
-        if (tensorHeight == 0) return
-        if (numChannel == 0) return
-        if (numElements == 0) return
+        var bestBoxes: List<BoundingBox>? = null
+        var inferenceTime = 0L
+        synchronized(executingLock) {
+            if (tensorWidth == 0) return
+            if (tensorHeight == 0) return
+            if (numChannel == 0) return
+            if (numElements == 0) return
 
-        var inferenceTime = SystemClock.uptimeMillis()
+            inferenceTime = SystemClock.uptimeMillis()
 
-        val resizedBitmap = Bitmap.createScaledBitmap(frame, tensorWidth, tensorHeight, false)
+            val resizedBitmap = Bitmap.createScaledBitmap(frame, tensorWidth, tensorHeight, false)
 
-        val tensorImage = TensorImage(INPUT_IMAGE_TYPE)
-        tensorImage.load(resizedBitmap)
-        val processedImage = imageProcessor.process(tensorImage)
-        val imageBuffer = processedImage.buffer
+            val tensorImage = TensorImage(INPUT_IMAGE_TYPE)
+            tensorImage.load(resizedBitmap)
+            val processedImage = imageProcessor.process(tensorImage)
+            val imageBuffer = processedImage.buffer
 
-        val output = TensorBuffer.createFixedSize(intArrayOf(1, numChannel, numElements), OUTPUT_IMAGE_TYPE)
-        interpreter.run(imageBuffer, output.buffer)
+            val output = TensorBuffer.createFixedSize(intArrayOf(1, numChannel, numElements), OUTPUT_IMAGE_TYPE)
+            interpreter?.run(imageBuffer, output.buffer)
 
-        val bestBoxes = bestBox(output.floatArray)
-        inferenceTime = SystemClock.uptimeMillis() - inferenceTime
-
+            bestBoxes = bestBox(output.floatArray)
+            inferenceTime = SystemClock.uptimeMillis() - inferenceTime
+        }
         if (bestBoxes == null) {
             detectorListener.onEmptyDetect()
             return
         }
-
-        detectorListener.onDetect(bestBoxes, inferenceTime)
+        detectorListener.onDetect(bestBoxes!!, inferenceTime)
     }
 
     private fun bestBox(array: FloatArray) : List<BoundingBox>? {

--- a/YOLOv9-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov9tflite/Detector.kt
+++ b/YOLOv9-Object-Detector-Android-Tflite/app/src/main/java/com/surendramaran/yolov9tflite/Detector.kt
@@ -121,6 +121,7 @@ class Detector(
         var bestBoxes: List<BoundingBox>? = null
         var inferenceTime = 0L
         synchronized(executingLock) {
+            if (interpreter == null) return
             if (tensorWidth == 0) return
             if (tensorHeight == 0) return
             if (numChannel == 0) return


### PR DESCRIPTION
While i was using the detector in other project, it would crash if i execute close() and detect() at the same time. Thus, I added a lock and check if the interpreter is still availible.